### PR TITLE
Update template to stop deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+
 Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CONTRIBUTING.md) on how to contribute to Cucumber.
 
 ## [master](https://github.com/cucumber/cucumber-rails/compare/1.5.0...master) (Not yet released)

--- a/config/cucumber.yml
+++ b/config/cucumber.yml
@@ -13,8 +13,8 @@ opts = [
 ]
 rails_version = `bundle exec rails --version`.match(/[\d.]+$/).to_s
 if Gem::Version.new(rails_version) < Gem::Version.new('4.2')
-  opts << '--tags ~@requires-rails-version-42'
+  opts << '--tags "not @requires-rails-version-42"'
 end
 optlist = opts.join(' ')
 %>
-default: <%= path %> <%= optlist %> --tags ~@broken
+default: <%= path %> <%= optlist %> --tags 'not @broken'

--- a/lib/cucumber/rails/capybara/javascript_emulation.rb
+++ b/lib/cucumber/rails/capybara/javascript_emulation.rb
@@ -98,7 +98,7 @@ class Capybara::RackTest::Node
   include ::Cucumber::Rails::Capybara::JavascriptEmulation
 end
 
-Before('~@no-js-emulation') do
+Before('not @no-js-emulation') do
   # Enable javascript emulation
   ::Capybara::RackTest::Node.class_eval do
     alias_method :click, :click_with_javascript_emulation

--- a/lib/cucumber/rails/hooks/active_record.rb
+++ b/lib/cucumber/rails/hooks/active_record.rb
@@ -11,7 +11,7 @@ if defined?(ActiveRecord::Base)
     Cucumber::Rails::Database.before_js if Cucumber::Rails::Database.autorun_database_cleaner
   end
 
-  Before('~@javascript') do
+  Before('not @javascript') do
     Cucumber::Rails::Database.before_non_js if Cucumber::Rails::Database.autorun_database_cleaner
   end
 

--- a/lib/cucumber/rails/hooks/database_cleaner.rb
+++ b/lib/cucumber/rails/hooks/database_cleaner.rb
@@ -1,11 +1,11 @@
 begin
   require 'database_cleaner'
 
-  Before('~@no-database-cleaner') do
+  Before('not @no-database-cleaner') do
     DatabaseCleaner.start if Cucumber::Rails::Database.autorun_database_cleaner
   end
 
-  After('~@no-database-cleaner') do
+  After('not @no-database-cleaner') do
     DatabaseCleaner.clean if Cucumber::Rails::Database.autorun_database_cleaner
   end
 

--- a/lib/generators/cucumber/install/templates/config/cucumber.yml.erb
+++ b/lib/generators/cucumber/install/templates/config/cucumber.yml.erb
@@ -1,8 +1,8 @@
 <%%
 rerun = File.file?('rerun.txt') ? IO.read('rerun.txt') : ""
 rerun_opts = rerun.to_s.strip.empty? ? "--format #{ENV['CUCUMBER_FORMAT'] || 'progress'} features" : "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} #{rerun}"
-std_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} --strict --tags ~@wip"
+std_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} --strict --tags 'not @wip'"
 %>
 default: <%= spork? ? '--drb ' : '' %><%%= std_opts %> features
 wip: <%= spork? ? '--drb ' : '' %>--tags @wip:3 --wip features
-rerun: <%= spork? ? '--drb ' : '' %><%%= rerun_opts %> --format rerun --out rerun.txt --strict --tags ~@wip
+rerun: <%= spork? ? '--drb ' : '' %><%%= rerun_opts %> --format rerun --out rerun.txt --strict --tags not @wip

--- a/lib/generators/cucumber/install/templates/support/_rails_each_run.rb.erb
+++ b/lib/generators/cucumber/install/templates/support/_rails_each_run.rb.erb
@@ -33,7 +33,7 @@ end
 #     DatabaseCleaner.strategy = :truncation
 #   end
 #
-#   Before('~@no-txn', '~@selenium', '~@culerity', '~@celerity', '~@javascript') do
+#   Before('not @no-txn', 'not @selenium', 'not @culerity', 'not @celerity', 'not @javascript') do
 #     DatabaseCleaner.strategy = :transaction
 #   end
 #


### PR DESCRIPTION
Fixes deprecation warnings like:

`Deprecated: Found tags option '~@wip'. Support for '~@tag' will be removed from the next release of Cucumber. Please use 'not @tag' instead.`